### PR TITLE
Improve configuration and add landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# KlimasunWebsite
-klimasun new website
+# Klimasun Website
+
+This repository contains the static files and admin scripts for the Klimasun demo website.
+
+## Local development
+
+You can preview the site by starting a simple HTTP server from the project root:
+
+```bash
+python3 -m http.server
+```
+
+Then open [http://localhost:8000/index.html](http://localhost:8000/index.html) in your browser.
+
+## Database configuration
+
+The admin PHP scripts read database credentials from environment variables. Set these before running the admin panel:
+
+- `DB_HOST` – database hostname (default `localhost`)
+- `DB_USER` – username (default `root`)
+- `DB_PASS` – password (default `123qwe`)
+- `DB_NAME` – database name (default `world`)
+
+Example on Linux:
+
+```bash
+export DB_HOST=localhost
+export DB_USER=myuser
+export DB_PASS=mypassword
+export DB_NAME=mydb
+```
+
+## Tests
+
+This project does not include automated tests.

--- a/admin/db_config.php
+++ b/admin/db_config.php
@@ -1,14 +1,14 @@
 <?php
-$servername = "localhost";
-$username = "root";
-$password = "123qwe";
-$dbname = "world";
+$servername = getenv('DB_HOST') ?: 'localhost';
+$username = getenv('DB_USER') ?: 'root';
+$password = getenv('DB_PASS') ?: '123qwe';
+$dbname   = getenv('DB_NAME') ?: 'world';
 
 try {
     $conn = new PDO("mysql:host=$servername;dbname=$dbname", $username, $password);
     $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $conn->exec("SET NAMES utf8");
-} catch(PDOException $e) {
+} catch (PDOException $e) {
     echo "Connection failed: " . $e->getMessage();
 }
-?> 
+?>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=pages/anasayfa.html">
+    <title>Klimasun</title>
+    <link rel="canonical" href="pages/anasayfa.html">
+</head>
+<body>
+    <p>Yönlendiriliyorsunuz... <a href="pages/anasayfa.html">Ana Sayfa</a></p>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- improve README with setup instructions
- support environment variables in PHP config
- add `index.html` redirect

## Testing
- `python3 -m http.server --bind 127.0.0.1 -d . >/tmp/server.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_686679ef7da883259eac032203e690b3