### PR TITLE
Improve configuration and add landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# KlimasunWebsite
-klimasun new website
+# Klimasun Website
+
+The site supports both Turkish and English.
+
+This repository contains the static files and admin scripts for the Klimasun demo website.
+
+## Local development
+
+You can preview the site by starting a simple HTTP server from the project root:
+
+```bash
+python3 -m http.server
+```
+
+Then open [http://localhost:8000/index.html](http://localhost:8000/index.html) in your browser.
+If your browser language is not Turkish, the landing page will automatically redirect you to the English version under `pages/en/home.html`.
+
+## Database configuration
+
+The admin PHP scripts read database credentials from environment variables. Set these before running the admin panel:
+
+- `DB_HOST` – database hostname (default `localhost`)
+- `DB_USER` – username (default `root`)
+- `DB_PASS` – password (default `123qwe`)
+- `DB_NAME` – database name (default `world`)
+
+Example on Linux:
+
+```bash
+export DB_HOST=localhost
+export DB_USER=myuser
+export DB_PASS=mypassword
+export DB_NAME=mydb
+```
+
+## Tests
+
+This project does not include automated tests.

--- a/admin/db_config.php
+++ b/admin/db_config.php
@@ -1,14 +1,14 @@
 <?php
-$servername = "localhost";
-$username = "root";
-$password = "123qwe";
-$dbname = "world";
+$servername = getenv('DB_HOST') ?: 'localhost';
+$username = getenv('DB_USER') ?: 'root';
+$password = getenv('DB_PASS') ?: '123qwe';
+$dbname   = getenv('DB_NAME') ?: 'world';
 
 try {
     $conn = new PDO("mysql:host=$servername;dbname=$dbname", $username, $password);
     $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $conn->exec("SET NAMES utf8");
-} catch(PDOException $e) {
+} catch (PDOException $e) {
     echo "Connection failed: " . $e->getMessage();
 }
-?> 
+?>

--- a/components/header.html
+++ b/components/header.html
@@ -34,7 +34,7 @@
                                     <a href="pages/allenbradley.html"><i class="fas fa-angle-right"></i> Allen Bradley</a>
                                     <a href="pages/siemens.html"><i class="fas fa-angle-right"></i> Siemens</a>
                                     <a href="pages/schneiderelectrics.html"><i class="fas fa-angle-right"></i> Schneider Electric</a>
-                                    <a href="pages/mitsubishi.html"><i class="fas fa-angle-right"></i> Mitsubishi Electric</a>
+                                    <a href="pages/mitsibushielectric.html"><i class="fas fa-angle-right"></i> Mitsubishi Electric</a>
                                 </div>
                             </div>
                             <div class="mega-menu-column">
@@ -42,8 +42,6 @@
                                 <div class="mega-menu-links">
                                     <a href="pages/lenze.html"><i class="fas fa-angle-right"></i> Lenze</a>
                                     <a href="pages/indramat.html"><i class="fas fa-angle-right"></i> Indramat</a>
-                                    <a href="pages/abb.html"><i class="fas fa-angle-right"></i> ABB</a>
-                                    <a href="pages/yaskawa.html"><i class="fas fa-angle-right"></i> Yaskawa</a>
                                 </div>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <title>Klimasun</title>
+    <script>
+        const lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+        if (lang && !lang.startsWith('tr')) {
+            window.location.replace('pages/en/home.html');
+        } else {
+            window.location.replace('pages/anasayfa.html');
+        }
+    </script>
+    <noscript>
+        <meta http-equiv="refresh" content="0; url=pages/anasayfa.html">
+    </noscript>
+</head>
+<body>
+    <p>Y\u00f6nlendiriliyorsunuz... <a href="pages/anasayfa.html">Ana Sayfa</a></p>
+</body>
+</html>
+

--- a/pages/en/home.html
+++ b/pages/en/home.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Klimasun - Home</title>
+    <link rel="stylesheet" href="../anasayfa.css">
+    <link rel="stylesheet" href="../../components/header.css">
+    <link rel="stylesheet" href="../../components/footer.css">
+</head>
+<body>
+    <div id="header-placeholder"></div>
+    <main class="page-content">
+        <section class="hero-section">
+            <h1>Welcome to Klimasun</h1>
+            <p>Your reliable source for industrial automation and climate solutions.</p>
+        </section>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script src="../../components/header.js"></script>
+    <script src="../../js/enhanced-rfq-button.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function(){
+        document.getElementById('header-placeholder').innerHTML = '';
+        fetch('../../components/header.html').then(r=>r.text()).then(t=>{document.getElementById('header-placeholder').innerHTML=t;});
+        document.getElementById('footer-placeholder').innerHTML = '';
+        fetch('../../components/footer.html').then(r=>r.text()).then(t=>{document.getElementById('footer-placeholder').innerHTML=t;});
+    });
+    </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -2,4 +2,4 @@
 document.querySelector('.search-box').addEventListener('click', function() {
     // Search functionality will be implemented here
     console.log('Search clicked');
-}); 
+});


### PR DESCRIPTION
## Summary
- improve README with setup instructions
- support environment variables in PHP config
- add `index.html` redirect
- add English landing page and fix header links

## Testing
- `python3 -m http.server --bind 127.0.0.1 -d . >/tmp/server.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_686679ef7da883259eac032203e690b3